### PR TITLE
Docker-multinode - Support for CoreOS

### DIFF
--- a/docker-multinode/common.sh
+++ b/docker-multinode/common.sh
@@ -40,7 +40,7 @@ kube::multinode::main(){
 
   ETCD_VERSION=${ETCD_VERSION:-"3.0.4"}
 
-  FLANNEL_VERSION=${FLANNEL_VERSION:-"0.6.0"}
+  FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.0"}
   FLANNEL_IPMASQ=${FLANNEL_IPMASQ:-"true"}
   FLANNEL_BACKEND=${FLANNEL_BACKEND:-"udp"}
   FLANNEL_NETWORK=${FLANNEL_NETWORK:-"10.1.0.0/16"}
@@ -149,7 +149,7 @@ kube::multinode::start_flannel() {
     --privileged \
     -v /dev/net:/dev/net \
     -v ${FLANNEL_SUBNET_DIR}:${FLANNEL_SUBNET_DIR} \
-    quay.io/coreos/flannel-${ARCH}:${FLANNEL_VERSION} \
+    quay.io/coreos/flannel:${FLANNEL_VERSION} \
     /opt/bin/flanneld \
       --etcd-endpoints=http://${MASTER_IP}:2379 \
       --ip-masq="${FLANNEL_IPMASQ}" \

--- a/docker-multinode/master.sh
+++ b/docker-multinode/master.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #
@@ -29,7 +29,7 @@ kube::multinode::turndown
 if [[ ${USE_CNI} == "true" ]]; then
   kube::cni::ensure_docker_settings
 
-  kube::multinode::start_etcd
+#  kube::multinode::start_etcd
 
   kube::multinode::start_flannel
 else


### PR DESCRIPTION
- This adds functionality to support running on CoreOS
- Uses CoreOS etcd that is running locally
